### PR TITLE
Fix Rabbie race patch failing

### DIFF
--- a/Patches/Rabbie The Moonrabbit/ThingDefs_Races/AlienRace_Rabbielike.xml
+++ b/Patches/Rabbie The Moonrabbit/ThingDefs_Races/AlienRace_Rabbielike.xml
@@ -9,18 +9,19 @@
 		<match Class="PatchOperationSequence">
 		<operations>
 			
-			<li Class="PatchOperationReplace">
-                    <xpath>/Defs/ThingDef[@Name="RB_PawnBase"]/inspectorTabs/li[.="ITab_Pawn_Gear"]</xpath>
-                    <value>
-                        <li>CombatExtended.ITab_Inventory</li>
-                    </value>
-			</li>
-
-            <li Class="PatchOperationAdd">
-                    <xpath>/Defs/ThingDef[@Name="RB_PawnBase"]/comps</xpath>
-                    <value>
-                        <li Class="CombatExtended.CompProperties_Inventory" />
-                    </value>
+			<li Class="PatchOperationConditional">
+				<xpath>/Defs/ThingDef[@Name="RB_PawnBase"]/comps</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[@Name="RB_PawnBase"]</xpath>
+					<value>
+						<comps/>
+					</value>
+				</nomatch>
+				<match Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[@Name="RB_PawnBase"]</xpath>
+					<value>
+					</value>
+				</match>
 			</li>
 			
 			<li Class="PatchOperationAdd">


### PR DESCRIPTION
Add comps, remove redundant Inventory (Rabbie inherits from BasePawn)

## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
