### PR TITLE
Fix Ratkin gizmo and gear tab

### DIFF
--- a/Patches/NewRatkinPlus/ThingDefs_Races/Race_Rakinlike.xml
+++ b/Patches/NewRatkinPlus/ThingDefs_Races/Race_Rakinlike.xml
@@ -116,32 +116,46 @@
 		</li>
 
 		<!-- Adding Inventory Support-->
-		<li Class="PatchOperationAdd">
-			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin" or defName="Ratkin_Su"]</xpath>
-			<value>
-			<inspectorTabs>
-				<li>CombatExtended.ITab_Inventory</li>
-			</inspectorTabs>				
-			</value>
-		</li>
-
-		<li Class="PatchOperationAdd">
-			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin" or defName="Ratkin_Su"]/comps</xpath>
-			<value>
-				<li Class="CombatExtended.CompProperties_Inventory" />
-			</value>
-		</li>
-
-		<li Class="PatchOperationAdd">
-			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin" or defName="Ratkin_Su"]/comps</xpath>
-			<value>
-				<li>
-				  <compClass>CombatExtended.CompPawnGizmo</compClass>
+		<li Class="PatchOperationConditional">
+					<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin" or defName="Ratkin_Su"]/comps</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin" or defName="Ratkin_Su"]</xpath>
+						<value>
+							<comps/>
+						</value>
+					</nomatch>
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin" or defName="Ratkin_Su"]</xpath>
+						<value>
+						</value>
+					</match>
 				</li>
-				<li Class="CombatExtended.CompProperties_Suppressable" />
-			</value>
-		</li>
 
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin" or defName="Ratkin_Su"]/comps</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin" or defName="Ratkin_Su"]</xpath>
+						<value>
+							<comps>
+								<li>
+									<compClass>CombatExtended.CompPawnGizmo</compClass>									
+								</li>
+								<li Class="CombatExtended.CompProperties_Suppressable" />
+							</comps>
+						</value>
+					</nomatch>
+					<match Class="PatchOperationReplace">
+						<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin" or defName="Ratkin_Su"]/comps</xpath>
+						<value>
+							<comps>
+								<li>
+									<compClass>CombatExtended.CompPawnGizmo</compClass>									
+								</li>
+								<li Class="CombatExtended.CompProperties_Suppressable" />
+							</comps>				
+						</value>
+					</match>
+				</li> 
 		<!-- Tweak weaponList -->
 		<li Class="PatchOperationRemove">
 			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin" or defName="Ratkin_Su"]/alienRace/raceRestriction/weaponList/li[.="RK_LongSword"]</xpath>


### PR DESCRIPTION
Similar to Revia. I don't know what I did but it works now.

## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
